### PR TITLE
Revert to building the windows package that includes the JRE.

### DIFF
--- a/package/create-release-packages.sh
+++ b/package/create-release-packages.sh
@@ -87,7 +87,7 @@ jar_file_name="HUSHSwingWalletUI.jar"
 
 
 ## Prepare Windows non-bundled zip release
-windows_release_package_name="hush-swing-${jar_release_verison}-hush-${hush_binary_release_version}-windows-x64"
+windows_release_package_name="hush-swing-${jar_release_verison}-hush-${hush_binary_release_version}--no-runtime--windows-x64"
 mkdir "${temporary_directory_path}/${windows_release_package_name}"
 unzip "${download_directory_path}/${windows_binaries_package}" -d "${temporary_directory_path}/${windows_release_package_name}"
 cp "package/supplemental-windows/reindex.bat" "${temporary_directory_path}/${windows_release_package_name}/"
@@ -103,42 +103,42 @@ sha256sum "${release_directory_path}/${windows_release_package_name}.zip" > "${r
 
 
 ## Prepare Windows runtime-bundled zip release
-#windows_full_release_package_name="hush-swing-${jar_release_verison}-hush-${hush_binary_release_version}-windows-x64"
-#mkdir "${temporary_directory_path}/${windows_full_release_package_name}"
-#mkdir "${temporary_directory_path}/${windows_full_release_package_name}/app"
+windows_full_release_package_name="hush-swing-${jar_release_verison}-hush-${hush_binary_release_version}-windows-x64"
+mkdir "${temporary_directory_path}/${windows_full_release_package_name}"
+mkdir "${temporary_directory_path}/${windows_full_release_package_name}/app"
 
 # Move our MSVC dependencies and `hush.exe` Java runtime loader, with it's `hush.cfg` file from their included archive
 # TODO: Eventually, avoid having this binary in this repository or as a hard-dependency at all
-#unzip "package/supplemental-windows/hush-jruntime-bootstrapper-windows-x64.zip" -d "${temporary_directory_path}/${windows_full_release_package_name}/"
+unzip "package/supplemental-windows/hush-jruntime-bootstrapper-windows-x64.zip" -d "${temporary_directory_path}/${windows_full_release_package_name}/"
 
-#unzip "${download_directory_path}/${windows_binaries_package}" -d "${temporary_directory_path}/${windows_full_release_package_name}/app/"
-#cp "package/supplemental-windows/reindex.bat" "${temporary_directory_path}/${windows_full_release_package_name}/app/"
-#cp "${build_output_jars_path}/${jar_file_name}" "${temporary_directory_path}/${windows_full_release_package_name}/app/"
-#cp LICENSE "${temporary_directory_path}/${windows_full_release_package_name}/LICENSE.txt"
+unzip "${download_directory_path}/${windows_binaries_package}" -d "${temporary_directory_path}/${windows_full_release_package_name}/app/"
+cp "package/supplemental-windows/reindex.bat" "${temporary_directory_path}/${windows_full_release_package_name}/app/"
+cp "${build_output_jars_path}/${jar_file_name}" "${temporary_directory_path}/${windows_full_release_package_name}/app/"
+cp LICENSE "${temporary_directory_path}/${windows_full_release_package_name}/LICENSE.txt"
 
 # Download Java SE JRE to be bundled
-#java_runtime_binary_package_name="server-jre-8u162-windows-x64"
-#wget --header "Cookie: oraclelicense=a" \
-# "http://download.oracle.com/otn-pub/java/jdk/8u162-b12/0da788060d494f5095bf8624735fa2f1/${java_runtime_binary_package_name}.tar.gz" \
-# -O "${download_directory_path}/${java_runtime_binary_package_name}.tar.gz"
-#cp "package/supplemental-windows/${java_runtime_binary_package_name}.tar.gz.sha256" "${download_directory_path}/"
-#cd "${download_directory_path}"
-#sha256sum -c "${java_runtime_binary_package_name}.tar.gz.sha256"
-#if [ "$?" != 0 ]; then
-#    cleanup_and_err "Unable to verify SHA256 checksum for ${binary_package}";
-#fi
-#cd "${PROJECT_ROOT}"
+java_runtime_binary_package_name="server-jre-8u181-windows-x64"
+wget --header "Cookie: oraclelicense=a" \
+ "http://download.oracle.com/otn-pub/java/jdk/8u181-b13/96a7b8442fe848ef90c96a2fad6ed6d1/${java_runtime_binary_package_name}.tar.gz" \
+ -O "${download_directory_path}/${java_runtime_binary_package_name}.tar.gz"
+cp "package/supplemental-windows/${java_runtime_binary_package_name}.tar.gz.sha256" "${download_directory_path}/"
+cd "${download_directory_path}"
+sha256sum -c "${java_runtime_binary_package_name}.tar.gz.sha256"
+if [ "$?" != 0 ]; then
+    cleanup_and_err "Unable to verify SHA256 checksum for ${binary_package}";
+fi
+cd "${PROJECT_ROOT}"
 
 # Move only the 'runtime' folder from the JRE distribution to be included in our release
-#mkdir "${temporary_directory_path}/${java_runtime_binary_package_name}"
-#tar -xzvf "${download_directory_path}/${java_runtime_binary_package_name}.tar.gz" -C "${temporary_directory_path}/${java_runtime_binary_package_name}"
-#cp -r "${temporary_directory_path}/${java_runtime_binary_package_name}/jdk1.8.0_162/jre" "${temporary_directory_path}/${windows_full_release_package_name}/runtime"
+mkdir "${temporary_directory_path}/${java_runtime_binary_package_name}"
+tar -xzvf "${download_directory_path}/${java_runtime_binary_package_name}.tar.gz" -C "${temporary_directory_path}/${java_runtime_binary_package_name}"
+cp -r "${temporary_directory_path}/${java_runtime_binary_package_name}/jdk1.8.0_181/jre" "${temporary_directory_path}/${windows_full_release_package_name}/runtime"
 
 # Make release file
-#cd "${temporary_directory_path}/${windows_full_release_package_name}"
-#zip -9r "${PROJECT_ROOT}/${release_directory_path}/${windows_full_release_package_name}.zip" *
-#cd "${PROJECT_ROOT}"
-#sha256sum "${release_directory_path}/${windows_full_release_package_name}.zip" > "${release_directory_path}/${windows_full_release_package_name}.zip.sha256"
+cd "${temporary_directory_path}/${windows_full_release_package_name}"
+zip -9r "${PROJECT_ROOT}/${release_directory_path}/${windows_full_release_package_name}.zip" *
+cd "${PROJECT_ROOT}"
+sha256sum "${release_directory_path}/${windows_full_release_package_name}.zip" > "${release_directory_path}/${windows_full_release_package_name}.zip.sha256"
 
 
 ## Prepare Mac OS non-bundled zip release

--- a/package/supplemental-windows/server-jre-8u162-windows-x64.tar.gz.sha256
+++ b/package/supplemental-windows/server-jre-8u162-windows-x64.tar.gz.sha256
@@ -1,1 +1,0 @@
-4a4d07429be8ef50ea1f80794dc85489db0b66db1f20e01a1ee38eaa19ec4789  server-jre-8u162-windows-x64.tar.gz

--- a/package/supplemental-windows/server-jre-8u181-windows-x64.tar.gz.sha256
+++ b/package/supplemental-windows/server-jre-8u181-windows-x64.tar.gz.sha256
@@ -1,0 +1,1 @@
+7799b9007760663da32a3b177a0b9ea42ec268afaa69dcf8518cdce5136c3768  server-jre-8u181-windows-x64.tar.gz


### PR DESCRIPTION
No runtime package is back to --no-runtime-- file.